### PR TITLE
corresponding dotnetcore

### DIFF
--- a/EmotionWeb-NETCore/EmotionWeb-NETCore.csproj
+++ b/EmotionWeb-NETCore/EmotionWeb-NETCore.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
-    <PackageReference Include="Microsoft.ProjectOxford.Emotion" Version="1.0.336" />
+    <PackageReference Include="Microsoft.ProjectOxford.Emotion.DotNetCore" Version="1.1.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
.netFrameworkで使っていたCognitive ServiceのSDKはdotnetcoreでは使えないようです
公式が配布しているdotnetCore用のSDKを指定することで無事動きました
[http://garicchi.com/?p=20366](http://garicchi.com/?p=20366)